### PR TITLE
Updated for Gnome 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,9 +3,9 @@
   "description": "Adds an icon for recently used items at the top panel; clear list by click; left click: open file, right click: open containing folder; Settings for: number of items, number of items under \"more\" and blacklisting options are defined at the top of extension.js (see https://github.com/bananenfisch/RecentItems for more infos).",
   "name": "Recent Items",
   "shell-version": [
-    "3.36", "40", "41"
+    "3.36", "40", "41", "42"
   ], 
-  "url": "http://www.bananenfisch.net/gnome",
+  "url": "https://github.com/bananenfisch/RecentItems",
   "uuid": "RecentItems@bananenfisch.net",
-  "version": 20
+  "version": 20.1
 }


### PR DESCRIPTION
- Added 42 to supported versions in metadata
- Aested it on GNOME 42 on Arch, Debian and Ubuntu
- Took the liberty to change the URL in the metadata to the github repo, because the supplied url doesn't work anymore.