### PR TITLE
Fix item sorting by modified datetime

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -37,7 +37,7 @@ const PopupMenu = imports.ui.popupMenu;
 const PanelMenu = imports.ui.panelMenu;
 
 function sortfunc(x,y) {
-  return y[0] - x[0];
+  return y[0].compare(x[0]);
 }
 
 var MyPopupMenuItem = GObject.registerClass({


### PR DESCRIPTION
Existing sortfunc() was returning NaN on Gnome 44.2.
Updated to use proper GDateTime compare() function.